### PR TITLE
Reduce TMC Current & Fix E0 Slave Address

### DIFF
--- a/firmware/Marlin-2.0.x-SKR-Mini-E3/Marlin/Configuration_adv.h
+++ b/firmware/Marlin-2.0.x-SKR-Mini-E3/Marlin/Configuration_adv.h
@@ -1715,7 +1715,7 @@
   #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
 
   #if AXIS_IS_TMC(X)
-    #define X_CURRENT     800  // (mA) RMS current. Multiply by 1.414 for peak current.
+    #define X_CURRENT     580  // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_MICROSTEPS   16  // 0..256
     #define X_RSENSE     0.11
   #endif
@@ -1727,7 +1727,7 @@
   #endif
 
   #if AXIS_IS_TMC(Y)
-    #define Y_CURRENT     800
+    #define Y_CURRENT     580
     #define Y_MICROSTEPS   16
     #define Y_RSENSE     0.11
   #endif
@@ -1739,7 +1739,7 @@
   #endif
 
   #if AXIS_IS_TMC(Z)
-    #define Z_CURRENT     800
+    #define Z_CURRENT     580
     #define Z_MICROSTEPS   16
     #define Z_RSENSE     0.11
   #endif
@@ -1757,7 +1757,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT    800
+    #define E0_CURRENT    650
     #define E0_MICROSTEPS  16
     #define E0_RSENSE    0.11
   #endif

--- a/firmware/Marlin-2.0.x-SKR-Mini-E3/Marlin/Configuration_adv.h
+++ b/firmware/Marlin-2.0.x-SKR-Mini-E3/Marlin/Configuration_adv.h
@@ -1838,8 +1838,8 @@
   #define X2_SLAVE_ADDRESS 0
   #define Y2_SLAVE_ADDRESS 0
   #define Z2_SLAVE_ADDRESS 0
-  #define Z3_SLAVE_ADDRESS 3
-  #define E0_SLAVE_ADDRESS 0
+  #define Z3_SLAVE_ADDRESS 0
+  #define E0_SLAVE_ADDRESS 3
   #define E1_SLAVE_ADDRESS 0
   #define E2_SLAVE_ADDRESS 0
   #define E3_SLAVE_ADDRESS 0

--- a/firmware/Marlin-2.0.x-SKR-Mini-E3/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/firmware/Marlin-2.0.x-SKR-Mini-E3/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1715,7 +1715,7 @@
   #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
 
   #if AXIS_IS_TMC(X)
-    #define X_CURRENT     800  // (mA) RMS current. Multiply by 1.414 for peak current.
+    #define X_CURRENT     580  // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_MICROSTEPS   16  // 0..256
     #define X_RSENSE     0.11
   #endif
@@ -1727,7 +1727,7 @@
   #endif
 
   #if AXIS_IS_TMC(Y)
-    #define Y_CURRENT     800
+    #define Y_CURRENT     580
     #define Y_MICROSTEPS   16
     #define Y_RSENSE     0.11
   #endif
@@ -1739,7 +1739,7 @@
   #endif
 
   #if AXIS_IS_TMC(Z)
-    #define Z_CURRENT     800
+    #define Z_CURRENT     580
     #define Z_MICROSTEPS   16
     #define Z_RSENSE     0.11
   #endif
@@ -1757,7 +1757,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT    800
+    #define E0_CURRENT    650
     #define E0_MICROSTEPS  16
     #define E0_RSENSE    0.11
   #endif


### PR DESCRIPTION
### Description
This PR reduces the current for TMC drivers since this config was using stock Marlin values and fixes TMC2209 E0 slave setting.

**Note:** Stock motors are rated from the manufacturer using peak values instead of RMS (See https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3-/issues/22#issuecomment-525808256 and [this gist](https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8) from @knoopx), which is why these values are less than the advertised ratings of 840mA for X/Y/Z and 1000mA for E.