### PR TITLE
[FIX #29] - correct the Y and Z s…

### DIFF
--- a/firmware/Marlin-2.0.x-SKR-Mini-E3/Marlin/Configuration_adv.h
+++ b/firmware/Marlin-2.0.x-SKR-Mini-E3/Marlin/Configuration_adv.h
@@ -1833,8 +1833,8 @@
    * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
-  #define  Y_SLAVE_ADDRESS 1
-  #define  Z_SLAVE_ADDRESS 2
+  #define  Y_SLAVE_ADDRESS 2
+  #define  Z_SLAVE_ADDRESS 1
   #define X2_SLAVE_ADDRESS 0
   #define Y2_SLAVE_ADDRESS 0
   #define Z2_SLAVE_ADDRESS 0


### PR DESCRIPTION
The Configuration_adv.h file should be update as following

#define X_SLAVE_ADDRESS 0
#define Y_SLAVE_ADDRESS 2
#define Z_SLAVE_ADDRESS 1

Checking the board schematic

Y driver

MS1 = Low
MS2 = High
Z driver

MS1 = High
MS2 = Low
and as the documentation explain the combination

Low/High => Y = 2
High/Low. => Z = 1